### PR TITLE
Handle new video schema

### DIFF
--- a/lib/forki/scrapers/post_scraper.rb
+++ b/lib/forki/scrapers/post_scraper.rb
@@ -17,7 +17,9 @@ module Forki
 
     def extract_post_data(graphql_strings)
       graphql_objects = graphql_strings.map { |graphql_object| JSON.parse(graphql_object) }
-      post_has_video = graphql_objects.any? { |graphql_object| graphql_object.keys.include?("video") }
+      post_has_video = graphql_strings.any? { |graphql_string| graphql_string.include? '"__typename":"Video"' }
+      # post_has_video = JSON.generate(graphql_objects.find { |g| g.keys.include? "node"}).include? '"__typename":"Video"'
+      # post_has_video = graphql_objects.any? { |graphql_object| graphql_object.keys.include?("video") }
       post_has_video ? extract_video_post_data(graphql_strings) : extract_image_post_data(graphql_objects)
     end
 
@@ -30,6 +32,33 @@ module Forki
         return extract_video_post_data_from_watch_page(graphql_strings)  # If this is a "watch page" video
       end
       graphql_object_array = graphql_strings.map { |graphql_string| JSON.parse(graphql_string) }
+      story_node_object = graphql_object_array.find { |graphql_object| graphql_object.keys.include? "node" }&.fetch("node", nil)  # user posted video
+      story_node_object = story_node_object || graphql_object_array.find { |graphql_object| graphql_object.keys.include? "nodes" }&.fetch("nodes")&.first  # page posted video
+      return extract_video_post_data_alternative(graphql_object_array) if story_node_object.nil?
+      video_object = story_node_object["comet_sections"]["content"]["story"]["attachments"].first["styles"]["attachment"]["media"]
+      feedback_object = story_node_object["comet_sections"]["feedback"]["story"]["feedback_context"]["feedback_target_with_context"]["ufi_renderer"]["feedback"]
+      reaction_counts = extract_reaction_counts(feedback_object["comet_ufi_summary_and_actions_renderer"]["feedback"]["cannot_see_top_custom_reactions"]["top_reactions"])
+      share_count_object = feedback_object.fetch("share_count", {})
+      post_details = {
+        id: video_object["id"],
+        num_comments: feedback_object["comment_count"]["total_count"],
+        num_shares: share_count_object.fetch("count", nil),
+        num_views: feedback_object["comet_ufi_summary_and_actions_renderer"]["feedback"]["video_view_count"],
+        reshare_warning: feedback_object["comet_ufi_summary_and_actions_renderer"]["feedback"]["should_show_reshare_warning"],
+        video_preview_image_url: video_object["preferred_thumbnail"]["image"]["uri"],
+        video_url: video_object["playable_url_quality_hd"] || video_object["playable_url"],
+        text: story_node_object["comet_sections"]["content"]["story"]["comet_sections"]["message"]["story"]["message"]["text"],
+        created_at: video_object["publish_time"],
+        profile_link: story_node_object["comet_sections"]["context_layout"]["story"]["comet_sections"]["actor_photo"]["story"]["actors"][0]["url"],
+        has_video: true
+      }
+      post_details[:video_preview_image_file] = Forki.retrieve_media(post_details[:video_preview_image_url])
+      post_details[:video_file] = Forki.retrieve_media(post_details[:video_url])
+      post_details[:reactions] = reaction_counts
+      post_details
+    end
+
+    def extract_video_post_data_alternative(graphql_object_array)
       sidepane_object = graphql_object_array.find { |graphql_object| graphql_object.keys.include?("tahoe_sidepane_renderer") }
       video_object = graphql_object_array.find { |graphql_object| graphql_object.keys == ["video"] }
       feedback_object = sidepane_object["tahoe_sidepane_renderer"]["video"]["feedback"]

--- a/test/post_test.rb
+++ b/test/post_test.rb
@@ -50,7 +50,8 @@ class PostTest < Minitest::Test
   end
 
   def test_a_video_post_by_a_user_returns_properly_when_scraped
-    posts = Forki::Post.lookup("https://www.facebook.com/cory.hurlburt/videos/10163562367665117/")
+    posts = Forki::Post.lookup(%w[ https://www.facebook.com/camille.mateo.90/posts/3046448408747570/
+                                        https://www.facebook.com/cory.hurlburt/videos/10163562367665117/])
     posts.each do |post|
       assert post.has_video
       assert post.num_views.positive?
@@ -68,10 +69,9 @@ class PostTest < Minitest::Test
   end
 
   def test_a_video_post_by_a_page_retuns_properly_when_scraped
-    urls = ["https://www.facebook.com/Meta/videos/264436895517475"]
-    # urls = %w[https://www.facebook.com/camille.mateo.90/videos/3046448408747570/
-    #           https://www.facebook.com/AmericaFirstAction/videos/323018088749144/
-    #           https://www.facebook.com/161453087348302/videos/684374025476745/]
+    urls = %w[https://www.facebook.com/161453087348302/videos/684374025476745/
+              https://www.facebook.com/AmericaFirstAction/videos/323018088749144/
+              https://www.facebook.com/Meta/videos/264436895517475]
     posts = Forki::Post.lookup(urls)
     posts.each do |post|
       assert post.has_video
@@ -114,7 +114,6 @@ class PostTest < Minitest::Test
     posts = Forki::Post.lookup(urls)
     posts.each do |post|
       assert post.has_video
-      # assert post.num_views > 0  # live videos may not have views listed
 
       assert post.num_comments.positive?
       assert post.reactions.length.positive?


### PR DESCRIPTION
Some video posts load with a different set of GraphQL objects than we're used to seeing. I have no idea why. As a stopgap until I can figure that out, I'm creating an alternative parsing method. 