### PR TITLE
Selenium fixes

### DIFF
--- a/lib/forki/scrapers/post_scraper.rb
+++ b/lib/forki/scrapers/post_scraper.rb
@@ -17,6 +17,7 @@ module Forki
     def extract_post_data(graphql_strings)
       graphql_objects = get_graphql_objects(graphql_strings)
       post_has_video = check_if_post_is_video(graphql_objects)
+      post_has_image = check_if_post_is_image(graphql_objects)
 
       # There's a chance it may be embedded in a comment chain like this:
       # https://www.facebook.com/PlandemicMovie/posts/588866298398729/
@@ -26,8 +27,10 @@ module Forki
         extract_video_post_data(graphql_strings)
       elsif post_has_video_in_comment_stream
         extract_video_comment_post_data(graphql_objects)
-      else
+      elsif post_has_image
         extract_image_post_data(graphql_objects)
+      else
+        raise ContentUnavailableError
       end
     end
 
@@ -37,6 +40,10 @@ module Forki
 
     def check_if_post_is_video(graphql_objects)
       graphql_objects.any? { |graphql_object| graphql_object.keys.include?("is_live_streaming") | graphql_object.keys.include?("video") }
+    end
+
+    def check_if_post_is_image(graphql_objects)
+      graphql_objects.any? { |graphql_object| graphql_object.keys.include?("image") | graphql_object.keys.include?("currMedia") }
     end
 
     def check_if_post_is_in_comment_stream(graphql_objects)

--- a/lib/forki/scrapers/post_scraper.rb
+++ b/lib/forki/scrapers/post_scraper.rb
@@ -242,12 +242,13 @@ module Forki
     def parse(url)
       validate_and_load_page(url)
       graphql_strings = find_graphql_data_strings(page.html)
-      page.quit
       post_data = extract_post_data(graphql_strings)
-
       user_url = post_data[:profile_link]
       post_data[:url] = url
+      page.quit # Close browser between page navigations to prevent cache folder access issues
+
       post_data[:user] = User.lookup(user_url).first
+      page.quit
       post_data
     end
   end

--- a/lib/forki/scrapers/post_scraper.rb
+++ b/lib/forki/scrapers/post_scraper.rb
@@ -255,7 +255,6 @@ module Forki
       page.quit # Close browser between page navigations to prevent cache folder access issues
 
       post_data[:user] = User.lookup(user_url).first
-      page.quit
       post_data
     end
   end

--- a/lib/forki/scrapers/scraper.rb
+++ b/lib/forki/scrapers/scraper.rb
@@ -92,27 +92,11 @@ module Forki
     # If either of those two conditions are false, raises an exception
     def validate_and_load_page(url)
       Capybara.app_host = "https://www.facebook.com"
-
       facebook_url = "https://www.facebook.com"
       visit "https://www.facebook.com" unless current_url.start_with?(facebook_url)
       login
       raise Forki::InvalidUrlError unless url.start_with?(facebook_url)
-
       visit url
-      retry_count = 0
-      while retry_count < 5
-        begin
-          raise Forki::ContentUnavailableError if all("span").any? { |span| span.text == "This Content Isn't Available Right Now" }
-          break
-        rescue Selenium::WebDriver::Error::StaleElementReferenceError
-          print({ error: "Error scraping spans", url: url, count: retry_count }.to_json)
-          retry_count += 1
-          raise Forki::RetryableError("Stale page element reference") if retry_count > 4
-          refresh
-          # Give it a second (well, five)
-          sleep(5)
-        end
-      end
     end
 
     # Extracts an integer out of a string describing a number

--- a/lib/forki/scrapers/user_scraper.rb
+++ b/lib/forki/scrapers/user_scraper.rb
@@ -61,6 +61,8 @@ module Forki
       is_page = graphql_strings.map { |s| JSON.parse(s) }.any? { |o| o.keys.include?("page") }
       user_details = is_page ? extract_page_details(graphql_strings) : extract_profile_details(graphql_strings)
 
+      page.quit
+
       user_details[:profile_image_file] = Forki.retrieve_media(user_details[:profile_image_url])
       user_details[:profile_link] = url
       user_details

--- a/lib/forki/user.rb
+++ b/lib/forki/user.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "byebug"
 module Forki
   class User
     def self.lookup(urls = [])

--- a/test/post_test.rb
+++ b/test/post_test.rb
@@ -130,7 +130,7 @@ class PostTest < Minitest::Test
   end
 
   def test_a_live_video_in_the_watch_tab_returns_properly_when_scraped
-    urls = %w[https://www.facebook.com/watch/live/?v=960083361438600]
+    urls = %w[https://www.facebook.com/watch/live/?v=394367115960503]
     posts = Forki::Post.lookup(urls)
     posts.each do |post|
       assert post.has_video

--- a/test/post_test.rb
+++ b/test/post_test.rb
@@ -154,6 +154,7 @@ class PostTest < Minitest::Test
   end
 
   def test_scraping_an_inaccessible_post_raises_a_content_not_available_exception
+    return
     assert_raises "content unavailable" do
       Forki::Post.lookup("https://www.facebook.com/redwhitebluenews/videos/258470355199081/")
     end

--- a/test/post_test.rb
+++ b/test/post_test.rb
@@ -154,7 +154,6 @@ class PostTest < Minitest::Test
   end
 
   def test_scraping_an_inaccessible_post_raises_a_content_not_available_exception
-    return
     assert_raises "content unavailable" do
       Forki::Post.lookup("https://www.facebook.com/redwhitebluenews/videos/258470355199081/")
     end


### PR DESCRIPTION
Until now, we've been searching for a 'content unavailable' span on each page we load. This led to us issuing thousands of Capybara requests to the browser for an element that didn't exist on most pages. 

This PR changes our method for recognizing when content is unavailable, greatly speeding up the scraping process. 

# Testing
1. `rails t`