### PR TITLE
Use spans to check if posts are unavailable

### DIFF
--- a/lib/forki.rb
+++ b/lib/forki.rb
@@ -35,6 +35,12 @@ module Forki
     end
   end
 
+  class UnhandledContentError < StandardError
+    def initialize(msg = "Forki does not know how to handle the post")
+      super
+    end
+  end
+
   define_setting :temp_storage_location, "tmp/forki"
 
 

--- a/lib/forki/scrapers/post_scraper.rb
+++ b/lib/forki/scrapers/post_scraper.rb
@@ -71,7 +71,7 @@ module Forki
 
     def check_if_post_is_unavailable
       begin
-        find("span", wait:5, text:"content isn't available right now", exact_text:false)
+        find("span", wait: 5, text: "content isn't available right now", exact_text: false)
       rescue Capybara::ElementNotFound
         false
       end

--- a/lib/forki/scrapers/post_scraper.rb
+++ b/lib/forki/scrapers/post_scraper.rb
@@ -18,6 +18,7 @@ module Forki
       graphql_objects = get_graphql_objects(graphql_strings)
       post_has_video = check_if_post_is_video(graphql_objects)
       post_has_image = check_if_post_is_image(graphql_objects)
+      post_is_unavailable = check_if_post_is_unavailable
 
       # There's a chance it may be embedded in a comment chain like this:
       # https://www.facebook.com/PlandemicMovie/posts/588866298398729/
@@ -29,8 +30,10 @@ module Forki
         extract_video_comment_post_data(graphql_objects)
       elsif post_has_image
         extract_image_post_data(graphql_objects)
-      else
+      elsif post_is_unavailable
         raise ContentUnavailableError
+      else
+        raise UnhandledContentError
       end
     end
 
@@ -61,6 +64,15 @@ module Forki
       end
 
       false
+    end
+
+    def check_if_post_is_unavailable
+      begin
+        find("span", wait:5, text:"content isn't available right now", exact_text:false)
+      rescue Capybara::ElementNotFound
+        false
+      end
+      true
     end
 
     def extract_video_comment_post_data(graphql_objects)

--- a/lib/forki/scrapers/post_scraper.rb
+++ b/lib/forki/scrapers/post_scraper.rb
@@ -46,7 +46,10 @@ module Forki
     end
 
     def check_if_post_is_image(graphql_objects)
-      graphql_objects.any? { |graphql_object| graphql_object.keys.include?("image") | graphql_object.keys.include?("currMedia") }
+      graphql_objects.any? do |graphql_object|  # if any GraphQL objects contain the top-level keys above, return true
+        true unless graphql_object.fetch("image", nil).nil? # so long as the associated values are not nil
+        true unless graphql_object.fetch("currMedia", nil).nil?
+      end
     end
 
     def check_if_post_is_in_comment_stream(graphql_objects)

--- a/test/post_test.rb
+++ b/test/post_test.rb
@@ -154,7 +154,7 @@ class PostTest < Minitest::Test
   end
 
   def test_scraping_an_inaccessible_post_raises_a_content_not_available_exception
-    assert_raises "content unavailable" do
+    assert_raises Forki::ContentUnavailableError do
       Forki::Post.lookup("https://www.facebook.com/redwhitebluenews/videos/258470355199081/")
     end
   end


### PR DESCRIPTION
Yes, we're going back to span searching, but we're adding a timeout, so they shouldn't lag the scraping process. We also won't check for the "content unavailable" span unless we've failed to find an image or video in the GraphQL strings. 

# Testing
1. `rake test`
2. Hypatia/Zeno/etc/etc