### PR TITLE
standardize media filenames across scrapers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     forki (0.1.0)
       apparition
       capybara
-      capybara-screenshot
       oj
       selenium-webdriver
       typhoeus
@@ -48,9 +47,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    capybara-screenshot (1.0.26)
-      capybara (>= 1.0, < 4)
-      launchy
     childprocess (4.1.0)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
@@ -61,8 +57,6 @@ GEM
     ffi (1.15.4)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    launchy (2.5.0)
-      addressable (~> 2.7)
     loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)

--- a/lib/forki.rb
+++ b/lib/forki.rb
@@ -53,16 +53,17 @@ module Forki
     response = Typhoeus.get(url)
 
     # Get the file extension if it's in the file
-    extension = url.split(".").last
+    stripped_url = url.split("?").first  # remove URL query params
+    extension = stripped_url.split(".").last
 
     # Do some basic checks so we just empty out if there's something weird in the file extension
     # that could do some harm.
     if extension.length.positive?
-      extension = nil unless /^[a-zA-Z0-9]+$/.match?(extension)
+      extension = nil unless /^[a-zA-Z0-9]{3}$/.match?(extension)  # extension must be a 3-character alphanumeric string
       extension = ".#{extension}" unless extension.nil?
     end
 
-    temp_file = "#{Forki.temp_storage_location}/#{SecureRandom.uuid}#{extension}"
+    temp_file = "#{Forki.temp_storage_location}/facebook_media_#{SecureRandom.uuid}#{extension}"
 
     # We do this in case the folder isn't created yet, since it's a temp folder we'll just do so
     create_temp_storage_location

--- a/lib/forki/scrapers/post_scraper.rb
+++ b/lib/forki/scrapers/post_scraper.rb
@@ -270,7 +270,7 @@ module Forki
       post_data = extract_post_data(graphql_strings)
       post_data[:url] = url
       user_url = post_data[:profile_link]
-      post_data[:screenshot_file] = save_screenshot("/tmp/#{SecureRandom.uuid}.png")
+      post_data[:screenshot_file] = save_screenshot("#{Forki.temp_storage_location}/facebook_screenshot_#{SecureRandom.uuid}.png")
 
       page.quit # Close browser between page navigations to prevent cache folder access issues
 


### PR DESCRIPTION
This PR, along with https://github.com/TechAndCheck/hypatia/pull/46, https://github.com/cguess/zorki/pull/15, and https://github.com/TechAndCheck/YoutubeArchiver/pull/7, standardizes media filenames across scrapers. It also fixes a bug in which extensions weren't being properly added to filenames. 

# Testing instructions
`rake test`