### PR TITLE
Remove Facebook's fact check overlay  before screenshotting posts

### DIFF
--- a/lib/forki/scrapers/post_scraper.rb
+++ b/lib/forki/scrapers/post_scraper.rb
@@ -310,7 +310,7 @@ module Forki
     def take_screenshot
       # First check whether post being scraped has a fact check overlay. If it does clear it.
       begin
-        find('div[aria-label=" See Photo "]').click()
+        find('div[aria-label=" See Photo "]').click() || find('div[aria-label=" See Video "]').click()
       rescue Capybara::ElementNotFound
         # Do nothing if element not found
       end

--- a/lib/forki/scrapers/post_scraper.rb
+++ b/lib/forki/scrapers/post_scraper.rb
@@ -307,6 +307,17 @@ module Forki
       end.inject { |emoji_counts, count| emoji_counts.merge(count) }
     end
 
+    def take_screenshot
+      # First check whether post being scraped has a fact check overlay. If it does clear it.
+      begin
+        find('div[aria-label=" See Photo "]').click()
+      rescue Capybara::ElementNotFound
+        # Do nothing if element not found
+      end
+
+      save_screenshot("#{Forki.temp_storage_location}/facebook_screenshot_#{SecureRandom.uuid}.png")
+    end
+
     # Uses GraphQL data and DOM elements to collect information about the current post
     def parse(url)
       validate_and_load_page(url)
@@ -317,7 +328,7 @@ module Forki
 
       5.times do
         begin
-          post_data[:screenshot_file] = save_screenshot("#{Forki.temp_storage_location}/facebook_screenshot_#{SecureRandom.uuid}.png")
+          post_data[:screenshot_file] = take_screenshot
           break
         rescue Net::ReadTimeout; end
 

--- a/lib/forki/scrapers/scraper.rb
+++ b/lib/forki/scrapers/scraper.rb
@@ -10,6 +10,7 @@ require "open-uri"
 options = Selenium::WebDriver::Chrome::Options.new
 options.add_argument("--window-size=1500,1500")
 options.add_argument("--no-sandbox")
+options.add_argument("--disable-notifications")
 options.add_argument("--disable-dev-shm-usage")
 options.add_argument("--user-data-dir=/tmp/tarun_forki_#{SecureRandom.uuid}")
 


### PR DESCRIPTION
When Facebook posts have been labeled as misinformation by fact checkers, Facebook adds an overlay to the post's media items, obscuring it like so:
![image](https://user-images.githubusercontent.com/9507998/206730869-d825d3c0-6d7d-4df7-a4ad-c6caf560b63a.png)

This PR adds functionality for Forki to click through the overlay so it can properly screenshot the media.

# Testing
1. `rake`
2. Use the hypatia console and this version of Forki to archive a [fact checked Facebook post](https://www.facebook.com/photo.php?fbid=3038249389564729&set=a.104631959593168&type=3). Make sure the screenshot Hypatia saves does not have a fact check overlay. 